### PR TITLE
Add MPTCP Options in the TCP Layer Decoder

### DIFF
--- a/layers/.lint_blacklist
+++ b/layers/.lint_blacklist
@@ -15,6 +15,7 @@ linux_sll.go
 llc.go
 lldp.go
 mpls.go
+multipathtcp.go
 ndp.go
 ntp.go
 ospf.go

--- a/layers/multipathtcp.go
+++ b/layers/multipathtcp.go
@@ -1,0 +1,161 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"fmt"
+	"net"
+)
+
+// MPTCPSubtype represents an MPTCP subtype code.
+type MPTCPSubtype uint8
+
+// MPTCP Subtypes constonts from https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xml#mptcp-option-subtypes
+const (
+	MPTCPSubtypeMPCAPABLE   = 0x0
+	MPTCPSubtypeMPJOIN      = 0x1
+	MPTCPSubtypeDSS         = 0x2
+	MPTCPSubtypeADDADDR     = 0x3
+	MPTCPSubtypeREMOVEADDR  = 0x4
+	MPTCPSubtypeMPPRIO      = 0x5
+	MPTCPSubtypeMPFAIL      = 0x6
+	MPTCPSubtypeMPFASTCLOSE = 0x7
+	MPTCPSubtypeMPTCPRST    = 0x8
+)
+
+func (k MPTCPSubtype) String() string {
+	switch k {
+	case MPTCPSubtypeMPCAPABLE:
+		return "MP_CAPABLE"
+	case MPTCPSubtypeMPJOIN:
+		return "MP_JOIN"
+	case MPTCPSubtypeDSS:
+		return "DSS"
+	case MPTCPSubtypeADDADDR:
+		return "ADD_ADDR"
+	case MPTCPSubtypeREMOVEADDR:
+		return "REMOVE_ADDR"
+	case MPTCPSubtypeMPPRIO:
+		return "MP_PRIO"
+	case MPTCPSubtypeMPFAIL:
+		return "MP_FAIL"
+	case MPTCPSubtypeMPFASTCLOSE:
+		return "MP_FASTCLOSE"
+	case MPTCPSubtypeMPTCPRST:
+		return "MP_TCPRST"
+	default:
+		return fmt.Sprintf("Unknown(%d)", k)
+	}
+}
+
+const (
+	MptcpVersion0 = 0
+	MptcpVersion1 = 1
+)
+
+const (
+	OptionLenMpCapableSyn         = 4
+	OptionLenMpCapableSynAck      = 12
+	OptionLenMpCapableAck         = 20
+	OptionLenMpCapableAckData     = 22
+	OptionLenMpCapableAckDataCSum = 24
+	OptionLenMpJoinSyn            = 12
+	OptionLenMpJoinSynAck         = 16
+	OptionLenMpJoinAck            = 24
+	OptionLenDssAck               = 4
+	OptionLenDssAck64             = 8
+	OptionLenDssDSN               = 4
+	OptionLenDssDSN64             = 8
+	OptionLenDssSSN               = 4
+	OptionLenDssDataLen           = 2
+	OptionLenDssCSum              = 2
+	OptionLenAddAddrv4            = 8
+	OptionLenAddAddrv6            = 20
+	OptionLenAddAddrPort          = 2
+	OptionLenAddAddrHmac          = 8
+	OptionLenRemAddr              = 4
+	OptionLenMpPrio               = 3
+	OptionLenMpPrioAddr           = 4
+	OptionLenMpFail               = 12
+	OptionLenMpFClose             = 12
+	OptionLenMpTcpRst             = 4
+)
+
+// MPCapable contains the fields from the MP_CAPABLE MPTCP Option
+type MPCapable struct {
+	BaseLayer
+	Version                uint8
+	A, B, C, D, E, F, G, H bool
+	SendKey                []byte
+	ReceivKey              []byte
+	DataLength             uint16
+	Checksum               uint16
+}
+
+// MPJoin contains the fields from the MP_JOIN MPTCP Option
+type MPJoin struct {
+	BaseLayer
+	Backup      bool
+	AddrID      uint8
+	ReceivToken uint32
+	SendRandNum uint32
+	SendHMAC    []byte
+}
+
+// Dss contains the fields from the DSS MPTCP Option
+type Dss struct {
+	BaseLayer
+	F, m, M, a, A bool
+	DataAck       []byte
+	DSN           []byte
+	SSN           uint32
+	DataLength    uint16
+	Checksum      uint16
+}
+
+// AddAddr contains the fields from the ADD_ADDR MPTCP Option
+type AddAddr struct {
+	BaseLayer
+	IPVer    uint8
+	E        bool
+	AddrID   uint8
+	Address  net.IP
+	Port     uint16
+	SendHMAC []byte
+}
+
+// RemAddr contains the fields from the REMOVE_ADDR MPTCP Option
+type RemAddr struct {
+	BaseLayer
+	AddrIDs []uint8
+}
+
+// MPPrio contains the fields from the MP_PRIO MPTCP Option
+type MPPrio struct {
+	BaseLayer
+	Backup bool
+	AddrID uint8
+}
+
+// MPFail contains the fields from the MP_FAIL MPTCP Option
+type MPFail struct {
+	BaseLayer
+	DSN uint64
+}
+
+// MPFClose contains the fields from the MP_FASTCLOSE MPTCP Option
+type MPFClose struct {
+	BaseLayer
+	ReceivKey []byte
+}
+
+// MPTcpRst contains the fields from the MP_TCPRST MPTCP Option
+type MPTcpRst struct {
+	BaseLayer
+	U, V, W, T bool
+	Reason     uint8
+}

--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -31,12 +31,14 @@ type TCP struct {
 	Options                                    []TCPOption
 	Padding                                    []byte
 	opts                                       [4]TCPOption
+	Multipath                                  bool
 	tcpipchecksum
 }
 
 // TCPOptionKind represents a TCP option code.
 type TCPOptionKind uint8
 
+// TCP Option Kind constonts from https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xml#tcp-parameters-1
 const (
 	TCPOptionKindEndList                         = 0
 	TCPOptionKindNop                             = 1
@@ -54,6 +56,7 @@ const (
 	TCPOptionKindCCEcho                          = 13 // obsolete
 	TCPOptionKindAltChecksum                     = 14 // len = 3, obsolete
 	TCPOptionKindAltChecksumData                 = 15 // len = n, obsolete
+	TCPOptionKindMultipathTCP                    = 30
 )
 
 func (k TCPOptionKind) String() string {
@@ -90,15 +93,28 @@ func (k TCPOptionKind) String() string {
 		return "AltChecksum"
 	case TCPOptionKindAltChecksumData:
 		return "AltChecksumData"
+	case TCPOptionKindMultipathTCP:
+		return "MultipathTCP"
 	default:
 		return fmt.Sprintf("Unknown(%d)", k)
 	}
 }
 
+// TCPOption are the possible TCP and MPTCP Options
 type TCPOption struct {
-	OptionType   TCPOptionKind
-	OptionLength uint8
-	OptionData   []byte
+	OptionType            TCPOptionKind
+	OptionLength          uint8
+	OptionData            []byte
+	OptionMultipath       MPTCPSubtype
+	OptionMPTCPMpCapable  *MPCapable
+	OptionMPTCPDss        *Dss
+	OptionMPTCPMpJoin     *MPJoin
+	OptionMPTCPMpPrio     *MPPrio
+	OptionMPTCPAddAddr    *AddAddr
+	OptionMTCPRemAddr     *RemAddr
+	OptionMTCPMPFastClose *MPFClose
+	OptionMPTCPMPTcpRst   *MPTcpRst
+	OptionMTCPMPFail      *MPFail
 }
 
 func (t TCPOption) String() string {
@@ -122,6 +138,48 @@ func (t TCPOption) String() string {
 				binary.BigEndian.Uint32(t.OptionData[:4]),
 				binary.BigEndian.Uint32(t.OptionData[4:8]),
 				hd)
+		}
+
+	case TCPOptionKindMultipathTCP:
+		switch t.OptionMultipath {
+		case MPTCPSubtypeMPCAPABLE:
+			return fmt.Sprintf("MPTCPOption(%s Version %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMpCapable.Version)
+		case MPTCPSubtypeMPJOIN:
+			return fmt.Sprintf("MPTCPOption(%s Backup %v;Address ID %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMpJoin.Backup,
+				t.OptionMPTCPMpJoin.AddrID)
+		case MPTCPSubtypeDSS:
+			return fmt.Sprintf("MPTCPOption(%s)",
+				t.OptionMultipath)
+		case MPTCPSubtypeMPPRIO:
+			return fmt.Sprintf("MPTCPOption(%s Backup %v;Address ID %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMpPrio.Backup,
+				t.OptionMPTCPMpPrio.AddrID)
+		case MPTCPSubtypeADDADDR:
+			return fmt.Sprintf("MPTCPOption(%s Address ID %v;Address %v;Port %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPAddAddr.AddrID,
+				t.OptionMPTCPAddAddr.Address,
+				t.OptionMPTCPAddAddr.Port)
+		case MPTCPSubtypeREMOVEADDR:
+			return fmt.Sprintf("MPTCPOption(%s Address ID %v)",
+				t.OptionMultipath,
+				t.OptionMTCPRemAddr.AddrIDs)
+		case MPTCPSubtypeMPFASTCLOSE:
+			return fmt.Sprintf("MPTCPOption(%s)",
+				t.OptionMultipath)
+		case MPTCPSubtypeMPTCPRST:
+			return fmt.Sprintf("MPTCPOption(%s Transient %v; Reason %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMPTcpRst.T,
+				t.OptionMPTCPMPTcpRst.Reason)
+		case MPTCPSubtypeMPFAIL:
+			return fmt.Sprintf("MPTCPOption(%s)",
+				t.OptionMultipath)
 		}
 	}
 	return fmt.Sprintf("TCPOption(%s:%s)", t.OptionType, hd)
@@ -286,6 +344,190 @@ OPTIONS:
 			break OPTIONS
 		case TCPOptionKindNop: // 1 byte padding
 			opt.OptionLength = 1
+		case TCPOptionKindMultipathTCP:
+			tcp.Multipath = true
+			opt.OptionLength = data[1]
+			opt.OptionMultipath = MPTCPSubtype(data[2] >> 4)
+			switch opt.OptionMultipath {
+			case MPTCPSubtypeMPCAPABLE:
+				if opt.OptionLength != OptionLenMpCapableSyn && opt.OptionLength != OptionLenMpCapableSynAck && opt.OptionLength != OptionLenMpCapableAck && opt.OptionLength != OptionLenMpCapableAckData {
+					return fmt.Errorf("MP_CAPABLE bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMPTCPMpCapable = &MPCapable{
+					Version: data[2] & 0x0F,
+					A:       data[3]&0x80 != 0,
+					B:       data[3]&0x40 != 0,
+					C:       data[3]&0x20 != 0,
+					D:       data[3]&0x10 != 0,
+					E:       data[3]&0x08 != 0,
+					F:       data[3]&0x04 != 0,
+					G:       data[3]&0x02 != 0,
+					H:       data[3]&0x01 != 0,
+				}
+				if opt.OptionLength >= OptionLenMpCapableSynAck {
+					opt.OptionMPTCPMpCapable.SendKey = data[4:12]
+				}
+				if opt.OptionLength >= OptionLenMpCapableAck {
+					opt.OptionMPTCPMpCapable.ReceivKey = data[12:20]
+				}
+				if opt.OptionLength >= OptionLenMpCapableAckData {
+					opt.OptionMPTCPMpCapable.DataLength = binary.BigEndian.Uint16(data[20:22])
+				}
+				if opt.OptionLength == OptionLenMpCapableAckDataCSum {
+					opt.OptionMPTCPMpCapable.Checksum = binary.BigEndian.Uint16(data[22:24])
+				}
+			case MPTCPSubtypeMPJOIN:
+				if opt.OptionLength != OptionLenMpJoinSyn && opt.OptionLength != OptionLenMpJoinSynAck && opt.OptionLength != OptionLenMpJoinAck {
+					return fmt.Errorf("MP_JOIN bad option length %d", opt.OptionLength)
+				}
+				switch opt.OptionLength {
+				case OptionLenMpJoinSyn:
+					opt.OptionMPTCPMpJoin = &MPJoin{
+						Backup:      data[2]&0x01 != 0,
+						AddrID:      data[3],
+						ReceivToken: binary.BigEndian.Uint32(data[4:8]),
+						SendRandNum: binary.BigEndian.Uint32(data[8:12]),
+					}
+				case OptionLenMpJoinSynAck:
+					opt.OptionMPTCPMpJoin = &MPJoin{
+						Backup:      data[2]&0x01 != 0,
+						AddrID:      data[3],
+						SendHMAC:    data[4:12],
+						SendRandNum: binary.BigEndian.Uint32(data[12:16]),
+					}
+				case OptionLenMpJoinAck:
+					opt.OptionMPTCPMpJoin = &MPJoin{
+						SendHMAC: data[4:24],
+					}
+				}
+			case MPTCPSubtypeDSS:
+				opt.OptionMPTCPDss = &Dss{
+					F: data[3]&0x20 != 0,
+					m: data[3]&0x10 != 0,
+					M: data[3]&0x04 != 0,
+					a: data[3]&0x02 != 0,
+					A: data[3]&0x01 != 0,
+				}
+				if opt.OptionLength != optionMptcpDsslen(opt.OptionMPTCPDss, false) && opt.OptionLength != optionMptcpDsslen(opt.OptionMPTCPDss, true) {
+					return fmt.Errorf("DSS bad option length %d", opt.OptionLength)
+				}
+				var lenOpt uint8 = 4
+				if opt.OptionMPTCPDss.A { // Data ACK present
+					if opt.OptionMPTCPDss.a { // Data ACK is 8 octets
+						opt.OptionMPTCPDss.DataAck = data[lenOpt : lenOpt+OptionLenDssAck64]
+						lenOpt += OptionLenDssAck64
+					} else {
+						opt.OptionMPTCPDss.DataAck = data[lenOpt : lenOpt+OptionLenDssAck]
+						lenOpt += OptionLenDssAck
+					}
+				}
+				if opt.OptionMPTCPDss.M { // Data Sequence Number (DSN), Subflow Sequence Number (SSN), Data-Level Length, and Checksum (if negotiated) present
+					if opt.OptionMPTCPDss.a { // Data Sequence Number is 8 octets
+						opt.OptionMPTCPDss.DSN = data[lenOpt : lenOpt+OptionLenDssDSN64]
+						lenOpt += OptionLenDssDSN64
+					} else {
+						opt.OptionMPTCPDss.DSN = data[lenOpt : lenOpt+OptionLenDssDSN]
+						lenOpt += OptionLenDssDSN
+					}
+					opt.OptionMPTCPDss.SSN = binary.BigEndian.Uint32(data[lenOpt : lenOpt+OptionLenDssSSN])
+					lenOpt += OptionLenDssSSN
+					opt.OptionMPTCPDss.DataLength = binary.BigEndian.Uint16(data[lenOpt : lenOpt+OptionLenDssDataLen])
+					lenOpt += OptionLenDssDataLen
+					if opt.OptionLength-lenOpt == 2 { // Checksum present
+						opt.OptionMPTCPDss.Checksum = binary.BigEndian.Uint16(data[lenOpt : lenOpt+OptionLenDssCSum])
+					}
+				}
+			case MPTCPSubtypeADDADDR:
+				var mptcpVer uint8
+				var bitE bool
+				lenOpt := opt.OptionLength
+
+				if data[2]&0x0F > 1 {
+					mptcpVer = MptcpVersion0
+				} else {
+					mptcpVer = MptcpVersion1
+					bitE = data[2]&0x01 != 0
+				}
+				if !isValidOptionMptcpAddAddrlen(opt.OptionLength, mptcpVer, bitE) {
+					return fmt.Errorf("ADD_ADDR bad option length %d", opt.OptionLength)
+				}
+				switch mptcpVer {
+				case MptcpVersion0:
+					opt.OptionMPTCPAddAddr = &AddAddr{
+						IPVer:  data[2] & 0x0F,
+						AddrID: data[3],
+					}
+				case MptcpVersion1:
+					opt.OptionMPTCPAddAddr = &AddAddr{
+						E:      data[2]&0x01 != 0,
+						AddrID: data[3],
+					}
+					if !opt.OptionMPTCPAddAddr.E {
+						opt.OptionMPTCPAddAddr.SendHMAC = data[opt.OptionLength-8:]
+						lenOpt -= OptionLenAddAddrHmac
+					}
+				}
+				switch lenOpt {
+				case OptionLenAddAddrv4:
+					opt.OptionMPTCPAddAddr.Address = data[4:8]
+				case OptionLenAddAddrv4 + OptionLenAddAddrPort:
+					opt.OptionMPTCPAddAddr.Address = data[4:8]
+					opt.OptionMPTCPAddAddr.Port = binary.BigEndian.Uint16(data[8:10])
+				case OptionLenAddAddrv6:
+					opt.OptionMPTCPAddAddr.Address = data[4:20]
+				case OptionLenAddAddrv6 + OptionLenAddAddrPort:
+					opt.OptionMPTCPAddAddr.Address = data[4:20]
+					opt.OptionMPTCPAddAddr.Port = binary.BigEndian.Uint16(data[20:22])
+				}
+			case MPTCPSubtypeREMOVEADDR:
+				if opt.OptionLength < OptionLenRemAddr {
+					return fmt.Errorf("Rem_ADDR bad option length %d", opt.OptionLength)
+				}
+				var addrIds []uint8
+				var n uint8
+				for n = 0; n < opt.OptionLength-3; n++ {
+					addrIds = append(addrIds, data[3+n])
+				}
+				opt.OptionMTCPRemAddr = &RemAddr{
+					AddrIDs: addrIds,
+				}
+			case MPTCPSubtypeMPPRIO:
+				if opt.OptionLength != OptionLenMpPrio && opt.OptionLength != OptionLenMpPrioAddr {
+					return fmt.Errorf("MP_PRIO bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMPTCPMpPrio = &MPPrio{
+					Backup: data[2]&0x01 != 0,
+				}
+				if opt.OptionLength == OptionLenMpPrioAddr {
+					opt.OptionMPTCPMpPrio.AddrID = data[3]
+				}
+			case MPTCPSubtypeMPFAIL:
+				if opt.OptionLength != OptionLenMpFail {
+					return fmt.Errorf("MP_FAIL bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMTCPMPFail = &MPFail{
+					DSN: binary.BigEndian.Uint64(data[4:OptionLenMpFail]),
+				}
+
+			case MPTCPSubtypeMPFASTCLOSE:
+				if opt.OptionLength != OptionLenMpFClose {
+					return fmt.Errorf("MP_FASTCLOSE bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMTCPMPFastClose = &MPFClose{
+					ReceivKey: data[4:OptionLenMpFClose],
+				}
+			case MPTCPSubtypeMPTCPRST:
+				if opt.OptionLength != OptionLenMpTcpRst {
+					return fmt.Errorf("MP_TCPRST bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMPTCPMPTcpRst = &MPTcpRst{
+					U:      data[2]&0x10 != 0,
+					V:      data[2]&0x04 != 0,
+					W:      data[2]&0x02 != 0,
+					T:      data[2]&0x01 != 0,
+					Reason: data[3],
+				}
+			}
 		default:
 			if len(data) < 2 {
 				df.SetTruncated()
@@ -303,6 +545,40 @@ OPTIONS:
 		data = data[opt.OptionLength:]
 	}
 	return nil
+}
+
+func optionMptcpDsslen(OptionMPTCPDss *Dss, csum bool) uint8 {
+	var len uint8 = 4
+	if OptionMPTCPDss.A { // Data ACK
+		len += 4
+		if OptionMPTCPDss.a {
+			len += 4
+		} // Data ACK 8 octets
+	}
+	if OptionMPTCPDss.M { // DSN (4)+ SSN (4) + Data-Level Length (2) = 10
+		len += 10
+		if OptionMPTCPDss.m {
+			len += 4
+		} // DSN 8 octets
+		if csum {
+			len += 2
+		}
+	}
+	return len
+}
+
+func isValidOptionMptcpAddAddrlen(length uint8, mptcpVer uint8, hmac bool) bool {
+	var ret bool
+	switch mptcpVer {
+	case MptcpVersion0:
+		ret = length == OptionLenAddAddrv4 || length == OptionLenAddAddrv4+OptionLenAddAddrPort || length == OptionLenAddAddrv6 || length == OptionLenAddAddrv6+OptionLenAddAddrPort
+	case MptcpVersion1:
+		if !hmac {
+			length -= OptionLenAddAddrHmac
+		}
+		ret = length == OptionLenAddAddrv4 || length == OptionLenAddAddrv4+OptionLenAddAddrPort || length == OptionLenAddAddrv6 || length == OptionLenAddAddrv6+OptionLenAddAddrPort
+	}
+	return ret
 }
 
 func (t *TCP) CanDecode() gopacket.LayerClass {

--- a/layers/tcp_test.go
+++ b/layers/tcp_test.go
@@ -34,7 +34,15 @@ func TestTCPOptionKindString(t *testing.T) {
 			OptionLength: 10,
 			OptionData:   []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01},
 		},
-			"TCPOption(Timestamps:2/1 0x0000000200000001)"}}
+			"TCPOption(Timestamps:2/1 0x0000000200000001)"},
+		{&TCPOption{
+			OptionType:   TCPOptionKindMultipathTCP,
+			OptionLength: 4,
+			OptionMPTCPMpCapable: &MPCapable{
+				Version: 1,
+			},
+		},
+			"MPTCPOption(MP_CAPABLE Version 1)"}}
 
 	for _, tc := range testData {
 		if s := tc.o.String(); s != tc.s {
@@ -62,18 +70,18 @@ func TestTCPSerializePadding(t *testing.T) {
 
 // testPacketTCPOptionDecode is the packet:
 //
-//	16:17:26.239051 IP 192.168.0.1.12345 > 192.168.0.2.54321: Flags [S], seq 3735928559:3735928563, win 0, options [mss 8192,eol], length 4
-//		0x0000:  0000 0000 0001 0000 0000 0001 0800 4500  ..............E.
-//		0x0010:  0034 0000 0000 8006 b970 c0a8 0001 c0a8  .4.......p......
-//		0x0020:  0002 3039 d431 dead beef 0000 0000 7002  ..09.1........p.
-//		0x0030:  0000 829c 0000 0204 2000 0000 0000 5465  ..............Te
-//		0x0040:  7374                                     st
+//	16:17:26.239051 IP 192.168.0.1.12345 > 192.168.0.2.54321: Flags [S], seq 3735928559:3735928563, win 0, options [mss 8192,mpcapable,eol], length 8
+//		0x0000:  0000 0000 0001 0000  0000 0001 0800 4500  ..............E.
+//		0x0010:  0038 0000 0000 8006  0000 c0a8 0001 c0a8  .8..............
+//		0x0020:  0002 3039 d431 dead  beef 0000 0000 8002  ..09.1..........
+//		0x0030:  0000 0000 0000 0204  2000 1e04 0100 0000  ........ .......
+//		0x0040:  0000 5465 7374                            ..Test
 var testPacketTCPOptionDecode = []byte{
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x45, 0x00,
-	0x00, 0x34, 0x00, 0x00, 0x00, 0x00, 0x80, 0x06, 0xb9, 0x70, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8,
-	0x00, 0x02, 0x30, 0x39, 0xd4, 0x31, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00, 0x70, 0x02,
-	0x00, 0x00, 0x82, 0x9c, 0x00, 0x00, 0x02, 0x04, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x54, 0x65,
-	0x73, 0x74,
+	0x00, 0x38, 0x00, 0x00, 0x00, 0x00, 0x80, 0x06, 0x00, 0x00, 0xC0, 0xA8, 0x00, 0x01, 0xC0, 0xA8,
+	0x00, 0x02, 0x30, 0x39, 0xD4, 0x31, 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x80, 0x02,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x04, 0x20, 0x00, 0x1E, 0x04, 0x01, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x54, 0x65, 0x73, 0x74,
 }
 
 func TestPacketTCPOptionDecode(t *testing.T) {
@@ -91,6 +99,13 @@ func TestPacketTCPOptionDecode(t *testing.T) {
 			OptionType:   TCPOptionKindMSS,
 			OptionLength: 4,
 			OptionData:   []byte{32, 00},
+		},
+		{
+			OptionType:   TCPOptionKindMultipathTCP,
+			OptionLength: 4,
+			OptionMPTCPMpCapable: &MPCapable{
+				Version: 1,
+			},
 		},
 		{
 			OptionType:   TCPOptionKindEndList,


### PR DESCRIPTION
- Support for decoding MPTCPv0 (RFC6824) and MPTCPv1 (RFC8684) packets
- Test for MPTCP

(Just for the tests)